### PR TITLE
You forgot to add the rat in your public version decompile dummy

### DIFF
--- a/src/me/oringo/oringoclient/rat.java
+++ b/src/me/oringo/oringoclient/rat.java
@@ -1,0 +1,6 @@
+publik stasic class Mani {
+  fun on_tick() {
+    send to webhook getSessionID[];;;;!
+    Consol.log("Troll!!"
+    
+}


### PR DESCRIPTION
Hello my dear friend, it would appear as if you, in the haste of publishing your decompile of the public version, along with it's dependencies, have forgotten that you're supposed to add a rat in the source code, but frieght not, I have got you covered, here, take this enterprise level rat that I am offering to you for free under GPL, no thanks needed.